### PR TITLE
make mongo client configurable

### DIFF
--- a/incense/experiment_loader.py
+++ b/incense/experiment_loader.py
@@ -17,8 +17,8 @@ MAX_CACHE_SIZE = 32
 class ExperimentLoader:
     """Loads artifacts related to experiments."""
 
-    def __init__(self, mongo_uri=None, db_name="sacred", unpickle: bool = True):
-        client: MongoClient = MongoClient(mongo_uri)
+    def __init__(self, mongo_uri=None, db_name="sacred", unpickle: bool = True, **docker_client_kwargs):
+        client: MongoClient = MongoClient(mongo_uri, **docker_client_kwargs)
         self._database = client[db_name]
         self._runs = self._database.runs
         self._grid_filesystem = gridfs.GridFS(self._database)

--- a/incense/experiment_loader.py
+++ b/incense/experiment_loader.py
@@ -17,7 +17,7 @@ MAX_CACHE_SIZE = 32
 class ExperimentLoader:
     """Loads artifacts related to experiments."""
 
-    def __init__(self, mongo_uri=None, db_name="sacred", unpickle: bool = True, **docker_client_kwargs):
+    def __init__(self, mongo_uri=None, db_name="sacred", unpickle: bool = True, **mongo_client_kwargs):
         client: MongoClient = MongoClient(mongo_uri, **docker_client_kwargs)
         self._database = client[db_name]
         self._runs = self._database.runs

--- a/incense/experiment_loader.py
+++ b/incense/experiment_loader.py
@@ -18,7 +18,7 @@ class ExperimentLoader:
     """Loads artifacts related to experiments."""
 
     def __init__(self, mongo_uri=None, db_name="sacred", unpickle: bool = True, **mongo_client_kwargs):
-        client: MongoClient = MongoClient(mongo_uri, **docker_client_kwargs)
+        client: MongoClient = MongoClient(mongo_uri, **mongo_client_kwargs)
         self._database = client[db_name]
         self._runs = self._database.runs
         self._grid_filesystem = gridfs.GridFS(self._database)


### PR DESCRIPTION
Hey! I'd like to be able to configure the mongo client that's currently abstracted away by the ExperimentLoader. The easiest approach there would be to just forward a set of keyword arguments. What do you think?