### PR TITLE
File storage experiment fix

### DIFF
--- a/incense/experiment.py
+++ b/incense/experiment.py
@@ -172,9 +172,8 @@ class FileSystemExperiment:
         reserved = {"run.json", "cout.txt", "metrics.json", "config.json", "info.json"}
         artifact_paths = (p for p in run_dir.iterdir() if p.name not in reserved and not p.is_dir())
         for artifact_path in artifact_paths:
-            artifact_file = artifact_path.open(mode="rb")
             name = artifact_path.name
-            artifacts[name] = Artifact(name, artifact_file)
+            artifacts[name] = Artifact(name, artifact_path)
 
         return artifacts
 

--- a/incense/experiment.py
+++ b/incense/experiment.py
@@ -143,7 +143,10 @@ class FileSystemExperiment:
     def from_run_dir(cls, run_dir: Path):
         id_ = int(run_dir.name)
         config = _load_json_from_path(run_dir / "config.json")
-        info = _load_json_from_path(run_dir / "info.json")
+        if "info.json" in [f.name for f in run_dir.iterdir()]:
+            info = _load_json_from_path(run_dir / "info.json")
+        else:
+            info = {}
         run_data = _load_json_from_path(run_dir / "run.json")
         cout = (run_dir / "cout.txt").read_text()
         run_data["config"] = config
@@ -166,7 +169,7 @@ class FileSystemExperiment:
     @staticmethod
     def _load_artifacts(run_dir: Path) -> Dict[str, Artifact]:
         artifacts = {}
-        reserved = {"run.json", "cout.txt", "metrics.json", "config.json"}
+        reserved = {"run.json", "cout.txt", "metrics.json", "config.json", "info.json"}
         artifact_paths = (p for p in run_dir.iterdir() if p.name not in reserved and not p.is_dir())
         for artifact_path in artifact_paths:
             artifact_file = artifact_path.open(mode="rb")


### PR DESCRIPTION
* `info.json` is not always created by `FileStorageObserver`, so load it only if the file exists in `run_dir`.
* Previously, artifacts were opened without being closed when loading artifacts. Now, just pass the path to the `Artifact` constructor instead of opening it.