### PR TITLE
Change deprecated `SafeConfigParser`

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -337,7 +337,7 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
         parser.readfp(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory


### PR DESCRIPTION
`SafeConfigParser` was deprecated in Python 3.2 in favor of `ConfigParser`. It was finally removed in Python 3.12, preventing incense to work in that version of Python.

This PR changes the name so that it can work again.